### PR TITLE
Change UMP kernel printing to use new _ump_printk()

### DIFF
--- a/drivers/gpu/mali/ump/common/ump_kernel_common.c
+++ b/drivers/gpu/mali/ump/common/ump_kernel_common.c
@@ -358,3 +358,15 @@ u32 _ump_ukk_report_memory_usage(void)
 	else
 		return 0;
 }
+
+void _ump_printk(const char *fmt, ...)
+{
+#if defined(CONFIG_MALI_QUIET)
+	(void)fmt;
+#else
+	va_list args;
+	va_start(args, fmt);
+	vprintk(fmt, args);
+	va_end(args);
+#endif /* !defined(CONFIG_MALI_QUIET) */
+}

--- a/drivers/gpu/mali/ump/common/ump_kernel_common.h
+++ b/drivers/gpu/mali/ump/common/ump_kernel_common.h
@@ -17,10 +17,11 @@
 #include "ump_kernel_random_mapping.h"
 #include "ump_kernel_memory_backend.h"
 
+extern void _ump_printk(const char * fmt, ...);
 
 #ifdef DEBUG
 extern int ump_debug_level;
-#define UMP_DEBUG_PRINT(args) _mali_osk_dbgmsg args
+#define UMP_DEBUG_PRINT(args) _ump_printk args
 #define UMP_DEBUG_CODE(args) args
 #define DBG_MSG(level,args)  do { /* args should be in brackets */ \
 		((level) <=  ump_debug_level)?\
@@ -53,15 +54,15 @@ extern int ump_debug_level;
 #endif /* DEBUG */
 
 #define MSG_ERR(args) do{ /* args should be in brackets */ \
-		_mali_osk_dbgmsg("UMP: ERR: %s\n" ,__FILE__); \
-		_mali_osk_dbgmsg( "           %s()%4d\n", __FUNCTION__, __LINE__) ; \
-		_mali_osk_dbgmsg args ; \
-		_mali_osk_dbgmsg("\n"); \
+		_ump_printk("UMP: ERR: %s\n" ,__FILE__); \
+		_ump_printk( "           %s()%4d\n", __FUNCTION__, __LINE__) ; \
+		_ump_printk args ; \
+		_ump_printk("\n"); \
 	} while(0)
 
 #define MSG(args) do{ /* args should be in brackets */ \
-		_mali_osk_dbgmsg("UMP: "); \
-		_mali_osk_dbgmsg args; \
+		_ump_printk("UMP: "); \
+		_ump_printk args; \
 	} while (0)
 
 


### PR DESCRIPTION
Change UMP kernel printing to use new _ump_printk(). This is required because the macros MSG_ERR and MSG just as UMP_DEBUG_PRINT used _mali_osk_dbgmsg, which is not defined in case MALI debugging ist turned off (CONFIG_MALI400_DEBUG not set).

A function equivalent to _masl_osk_dbgmsg() has been added to ump_kernel_common.c
