### PR TITLE
sunxi-3.4 fixes and (mainline) U-Boot compatibility

### DIFF
--- a/arch/arm/boot/compressed/head.S
+++ b/arch/arm/boot/compressed/head.S
@@ -133,7 +133,61 @@ start:
 		.word	start			@ absolute load/run zImage address
 		.word	_edata			@ zImage end address
  THUMB(		.thumb			)
-1:		mov	r7, r1			@ save architecture ID
+1:
+
+/******************************************************************************/
+/*
+ * This is a hack to implement the compatibility check between the mainline
+ * U-Boot and the legacy sunxi-3.4 kernel. We interpret the top 4 bits of the
+ * machine id as a some sort of a machine id compatibility revision number.
+ *
+ * The expected workflow:
+ *
+ * 1. U-Boot introduces some changes, which may expose some serious bug in
+ *    the sunxi-3.4 kernel. For example, changes the PLL5P clock speed.
+ *    So that the kernel needs bugfixes like:
+ *        https://github.com/linux-sunxi/linux-sunxi/commit/9a1cd034181af628d41
+ *        https://github.com/linux-sunxi/linux-sunxi/commit/ade08aa6e5249a9e75a
+ *
+ *    And U-Boot bumps the compatibility revision number in the machine id at
+ *    the same time. For example, changes the 'include/configs/sun4i.h' from
+ *
+ *        #define CONFIG_MACH_TYPE 4104
+ *
+ *    into
+ *
+ *        #define CONFIG_MACH_TYPE_COMPAT_REV 1
+ *        #define CONFIG_MACH_TYPE (4104 | (CONFIG_MACH_TYPE_COMPAT_REV << 28))
+ *
+ * 2. The sunxi-3.4 kernel applies the necessary bugfixes to the code and also
+ *    bumps the CONFIG_MACH_TYPE_COMPAT_REV number in this file in the kernel.
+ *
+ * The effect of this is the following. If somebody tries to boot some old
+ * kernel with the new incompatible U-Boot, then the top bits of the machine
+ * id will be non-zero and the kernel will refuse to load because of the
+ * machine id mismatch. The appropriate error message will show on the serial
+ * console, and this error message is very much googlable. The linux-sunxi wiki
+ * can contain the necessary explanations about how to resolve this situation.
+ *
+ * If somebody tries to boot an appropriately fixed revison of the sunxi-3.4
+ * kernel with the new U-Boot, then the top 4 bits of the machine id will be
+ * cleared by the code in this assembly file after passing the revision check.
+ *
+ * If somebody tries to boot an appropriately fixed revison of the sunxi-3.4
+ * kernel with a very old U-Boot (for example, the legacy u-boot-sunxi), then
+ * everything will be fine too.
+ */
+		#define CONFIG_MACH_TYPE_COMPAT_REV 1
+
+		/* Extract the machine id compatibility revision number */
+		mov	r7, r1, lsr #28
+		cmp	r7, #CONFIG_MACH_TYPE_COMPAT_REV
+		/* Clear the top 4 bits if the compatibility check succeeded */
+		bicle	r1, r1, #(0xF << 28)
+
+/******************************************************************************/
+
+		mov	r7, r1			@ save architecture ID
 		mov	r8, r2			@ save atags pointer
 
 #ifndef __ARM_ARCH_2__

--- a/arch/arm/mach-sun5i/clock/clock.c
+++ b/arch/arm/mach-sun5i/clock/clock.c
@@ -169,18 +169,15 @@ int clk_init(void)
     tmpSclk->set_clk(tmpSclk->clk);
 
     tmpSclk = &ccu_sys_clk[AW_SYS_CLK_PLL6];
-    tmpSclk->clk->rate  = 600000000;
-    tmpSclk->set_clk(tmpSclk->clk);
+    tmpSclk->clk = aw_ccu_get_sys_clk(tmpSclk->clk->id);
     tmpSclk->clk->onoff = AW_CCU_CLK_ON;
     tmpSclk->set_clk(tmpSclk->clk);
     tmpSclk = &ccu_sys_clk[AW_SYS_CLK_PLL6M];
-    tmpSclk->clk->rate  = 100000000;
-    tmpSclk->set_clk(tmpSclk->clk);
+    tmpSclk->clk = aw_ccu_get_sys_clk(tmpSclk->clk->id);
     tmpSclk->clk->onoff = AW_CCU_CLK_ON;
     tmpSclk->set_clk(tmpSclk->clk);
     tmpSclk = &ccu_sys_clk[AW_SYS_CLK_PLL62];
-    tmpSclk->clk->rate  = 300000000;
-    tmpSclk->set_clk(tmpSclk->clk);
+    tmpSclk->clk = aw_ccu_get_sys_clk(tmpSclk->clk->id);
     tmpSclk->clk->onoff = AW_CCU_CLK_ON;
     tmpSclk->set_clk(tmpSclk->clk);
 

--- a/drivers/block/sunxi_nand/nfd/nand_blk.c
+++ b/drivers/block/sunxi_nand/nfd/nand_blk.c
@@ -1095,16 +1095,15 @@ __u32 get_cmu_clk(void)
 {
 	__u32 reg_val;
 	__u32 div_p, factor_n;
-	__u32 factor_k, factor_m;
+	__u32 factor_k;
 	__u32 clock;
 
 	reg_val  = *(volatile unsigned int *)(0xf1c20000 + 0x20);
 	div_p    = (reg_val >> 16) & 0x3;
 	factor_n = (reg_val >> 8) & 0x1f;
 	factor_k = ((reg_val >> 4) & 0x3) + 1;
-	factor_m = ((reg_val >> 0) & 0x3) + 1;
 
-	clock = 24 * factor_n * factor_k/div_p/factor_m;
+	clock = (24 * factor_n * factor_k) >> div_p;
 
 	return clock;
 }

--- a/drivers/power/axp152.c
+++ b/drivers/power/axp152.c
@@ -541,25 +541,30 @@ static struct regulator_init_data regl_init_data[AXP152_REGULATOR_COUNT] = {
 			.valid_ops_mask = REGULATOR_CHANGE_VOLTAGE,
 		}
 	},
-	[axp152_dcdc3] = { /* Vddr, power on 1.5V, Android from fex */
+	[axp152_dcdc3] = { /* Vddr, power on 1.5V, use u-boot value */
 		.num_consumer_supplies = 1,
 		.consumer_supplies = &axp152_dcdc3_supply,
 		.constraints = {
-			.min_uV =  1500 * 1000,
-			.max_uV =  1500 * 1000,
+			.min_uV =  1000 * 1000,
+			.max_uV =  1600 * 1000,
 			.always_on = 1,
-			.apply_uV = 1,
-			.valid_ops_mask = REGULATOR_CHANGE_VOLTAGE,
+			/*
+			 * We do not allow changing the DRAM voltage, because
+			 * of stability, so no REGULATOR_CHANGE_VOLTAGE.
+			 */
 		}
 	},
-	[axp152_dcdc4] = { /* Vcpu, power on 1.25V, Android from fex */
+	[axp152_dcdc4] = { /* VDD-INT/VDD-DLL, power on 1.25V, use u-boot value */
 		.num_consumer_supplies = 1,
 		.consumer_supplies = &axp152_dcdc4_supply,
 		.constraints = {
-			.min_uV =  1250 * 1000,
-			.max_uV =  1250 * 1000,
+			.min_uV =  1000 * 1000,
+			.max_uV =  1600 * 1000,
 			.always_on = 1,
-			.apply_uV = 1,
+			/*
+			 * We do not allow changing the DLL voltage, because
+			 * of stability, so no REGULATOR_CHANGE_VOLTAGE.
+			 */
 		}
 	},
 	[axp152_dldo2] = { /* Power on 1.8V, Android hardcoded 3.0V */
@@ -622,17 +627,11 @@ static int __init axp_board_init(void)
 
 	/* Note we ignore the dcdc2_vol key as dcdc2 is set by the dvfs code */
 
-	ret = script_parser_fetch("target", "dcdc3_vol", &val, sizeof(int));
-	if (ret == 0) {
-		regl_init_data[axp152_dcdc3].constraints.min_uV = val * 1000;
-		regl_init_data[axp152_dcdc3].constraints.max_uV = val * 1000;
-	}
-
-	ret = script_parser_fetch("target", "dcdc4_vol", &val, sizeof(int));
-	if (ret == 0) {
-		regl_init_data[axp152_dcdc4].constraints.min_uV = val * 1000;
-		regl_init_data[axp152_dcdc4].constraints.max_uV = val * 1000;
-	}
+	/*
+	 * Note we ignore the dcdc3_vol and dcdc4_vol keys as those sometimes
+	 * contain wrong values making the dram unstable, instead we stick with
+	 * the voltage set by the bootloader.
+	 */
 
 	return i2c_register_board_info(i2c_bus, &axp_mfd_i2c_board_info, 1);
 }


### PR DESCRIPTION
For improved stability and smooth interoperability with up-to-date U-Boot it's desirable to incorporate a number of changes from `sunxi-3.4`. For the rationale behind them see [this section on the linux-sunxi Wiki](http://linux-sunxi.org/Mainline_U-Boot#Unrecognized.2Funsupported_machine_ID).

Commit e2b5cbfd11d4a28430c9bef6656ef6336bf4fe40 already included two of the patches listed there, and the remaining five apply cleanly on top of your current tree. This pull request has them squashed into a single commit.

Regards, NiteHawk
